### PR TITLE
RF: Clean up config class, add documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+    -   id: pretty-format-json
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    -   id: black
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+    -   id: isort
+        name: isort (python)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
-## Migas Client
+# Migas Client
 
 A Python package to communicate with a migas server.
+
+## API
+
+`migas` includes the following functions to communicate with the telemetry server:
+
+### migas.add_project()
+
+Send a breadcrumb with usage information to the server.
+The server will attempt to return information about the project,
+such as the latest version and bad versions.
+
+### migas.from_date_range()
+
+Check number of uses a project has received from a start date, and optionally an end date.
+If no end date is specified, the datetime is used.
+
+## Customization
+
+Normally, calling `migas.setup()` will populate the internal configuration with the default endpoint,
+but in cases where you wish to host your own instance of a `migas` server,
+you can pass in an `endpoint` parameter to route traffic accordingly.

--- a/migas/config.py
+++ b/migas/config.py
@@ -6,7 +6,7 @@ import typing
 import uuid
 
 
-DEFAULT_ENDPOINT = "http://0.0.0.0:8000/graphql"  # localhost test
+DEFAULT_ENDPOINT = 'https://migas.herokuapp.com/graphql'
 DEFAULT_CONFIG_FILE = Path.home() / '.cache' / 'migas' / 'config.json'
 
 # TODO: 3.10 - Replace with | operator

--- a/migas/config.py
+++ b/migas/config.py
@@ -1,10 +1,10 @@
-from dataclasses import dataclass
 import json
 import os
-from pathlib import Path
 import typing
 import uuid
-
+from dataclasses import dataclass
+from functools import wraps
+from pathlib import Path
 
 DEFAULT_ENDPOINT = 'https://migas.herokuapp.com/graphql'
 DEFAULT_CONFIG_FILE = Path.home() / '.cache' / 'migas' / 'config.json'
@@ -13,19 +13,55 @@ DEFAULT_CONFIG_FILE = Path.home() / '.cache' / 'migas' / 'config.json'
 File = typing.Union[str, Path]
 
 
-@dataclass
+def suppress_errors(func):
+    """Decorator to silently fail the wrapped function"""
+
+    @wraps(func)
+    def safe(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception:
+            pass
+
+    return safe
+
+
+def telemetry_enabled(func: typing.Callable) -> typing.Callable:
+    """Decorator function to verify telemetry collection is enabled."""
+
+    @wraps(func)
+    def can_send(*args, **kwargs):
+        if not os.getenv("ENABLE_MIGAS", "0").lower() in ("1", "true", "y", "yes"):
+            # do not communicate with server
+            return {
+                "success": False,
+                "errors": [
+                    {"message": "migas is not enabled - set ENABLE_MIGAS environment variable."}
+                ],
+            }
+        # otherwise, ensure config is set up
+        setup()
+        return func(*args, **kwargs)
+
+    return can_send
+
+
+@dataclass(init=False, repr=False, eq=False)
 class Config:
     """
     Class to store client-side configuration, facilitating communication with the server.
 
     The class stores the following components:
     - `endpoint`:
-    The URL of the migas server
+    URL of the graphql endpoint of the migas server.
     - `user_id`:
     A string representation of a UUID (RFC 4122) assigned to the user.
     - `session_id`:
     A string representation of a UUID assigned to the lifespan of the migas invocation.
+
+    This class is not meant to be initialized, instead usage depends on class attributes.
     """
+
     endpoint: str = None
     user_id: str = None
     session_id: str = None
@@ -40,6 +76,11 @@ class Config:
         session_id: str = None,
         final: bool = True,
     ) -> None:
+        """
+        Setup migas configuration.
+
+        If class was already configured, existing configuration is used.
+        """
         if cls._is_setup:
             return
         if endpoint is not None:
@@ -61,26 +102,23 @@ class Config:
                 pass
         cls._is_setup = final
 
-
     @classmethod
+    @suppress_errors
     def load(cls, filename: File) -> bool:
         """Load existing configuration file, or create a new one."""
         config = json.loads(Path(filename).read_text())
         cls.init(final=False, **config)
         return True
 
-
     @classmethod
+    @suppress_errors
     def save(cls, filename: File) -> str:
         """Save to a JSON file."""
-        config = {
-            field: getattr(cls, field) for field in cls.__annotations__.keys()
-        }
+        config = {field: getattr(cls, field) for field in cls.__annotations__.keys()}
         # TODO: Make safe when multiprocessing
         Path(filename).parent.mkdir(parents=True, exist_ok=True)
         Path(filename).write_text(json.dumps(config))
         return str(filename)
-
 
     @classmethod
     def _reset(cls):

--- a/migas/operations.py
+++ b/migas/operations.py
@@ -1,15 +1,12 @@
 """
 Create queries and mutations to be sent to the graphql endpoint.
 """
-from functools import wraps
-import os
 import sys
 import typing
 from uuid import UUID
 
-from .config import Config, setup
-from .request import request
-
+from migas.config import Config, telemetry_enabled
+from migas.request import request
 
 if sys.version_info[:2] < (3, 8):
     from typing_extensions import TypedDict
@@ -20,28 +17,6 @@ else:
 class OperationTemplate(TypedDict):
     operation: str
     args: dict
-
-
-def telemetry_check(func: typing.Callable) -> typing.Callable:
-    """Decorator function to ensure telemetry collection is enabled."""
-
-    @wraps(func)
-    def can_send(*args, **kwargs):
-        if not os.getenv("ENABLE_MIGAS", "0").lower() in ("1", "true", "y", "yes"):
-            # do not communicate with server
-            return {
-                "success": False,
-                "errors": [
-                    {
-                        "message": "migas is not enabled - set `ENABLE_MIGAS` environment variable."
-                    }
-                ],
-            }
-        # otherwise, ensure config is set up
-        setup()
-        return func(*args, **kwargs)
-
-    return can_send
 
 
 fromDateRange: OperationTemplate = {
@@ -57,7 +32,7 @@ fromDateRange: OperationTemplate = {
 }
 
 
-@telemetry_check
+@telemetry_enabled
 def from_date_range(
     project: str,
     start: str,
@@ -90,7 +65,7 @@ addProject: OperationTemplate = {
 }
 
 
-@telemetry_check
+@telemetry_enabled
 def add_project(
     project: str,
     project_version: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+line-length = 99
+target-version = ['py310']
+skip-string-normalization = true
+extend-exclude = '_version.py|versioneer.py'
+
+[tool.isort]
+profile = 'black'
+extend_skip = '_version.py'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [metadata]
-url = https://github.com/mgxd/migas-py
 description = Migas Python client
 license = Apache License, 2.0
 long_description = file:README.md
@@ -14,6 +13,9 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+project_urls =
+    Source Code=https://github.com/mgxd/migas-py
+    Bug Tracker=https://github.com/mgxd/migas-py/issues
 
 [options]
 python_requires = >= 3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,9 @@ install_requires =
     typing_extensions; python_version<'3.8'
 
 [options.extras_require]
+dev =
+    black
+    isort
 test =
     pytest
 


### PR DESCRIPTION
Preparation for first release.

- Converts configuration `load`/`save` functions to classmethods.
- Change default endpoint to heroku hosted app.
- Add `suppress_errors` decorator to avoid affecting upstream applications.
- Add style requirements (`black`/`isort`) to dev requirements.
- Add documentation for usage.