### PR TITLE
ENH: Loosen `add_project` requirements, gather additional info

### DIFF
--- a/migas/operations.py
+++ b/migas/operations.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from migas.config import Config, telemetry_enabled
 from migas.request import request
+from migas.utils import compile_info
 
 if sys.version_info[:2] < (3, 8):
     from typing_extensions import TypedDict
@@ -69,15 +70,17 @@ addProject: OperationTemplate = {
 def add_project(
     project: str,
     project_version: str,
-    language: str,
-    language_version: str,
-    userId: UUID = None,
-    sessionId: UUID = None,
+    language: str = None,
+    language_version: str = None,
+    user_id: UUID = None,
+    session_id: UUID = None,
     container: str = None,
     platform: str = None,
     arguments: list = None,
 ) -> dict:
-    params = _introspec(add_project, locals())
+    parameters = _introspec(add_project, locals())
+    # TODO: 3.9 - Replace with | operator
+    params = {**compile_info(), **parameters}
     query = _formulate_query(params, addProject)
     status, response = request(Config.endpoint, query)
     return status, response

--- a/migas/utils.py
+++ b/migas/utils.py
@@ -1,11 +1,12 @@
 """Utility functions"""
-from pathlib import Path
 import platform
 import sys
+from pathlib import Path
 
 
 def is_ci():
     ...
+
 
 def is_container():
     root = Path('/')
@@ -18,8 +19,9 @@ def is_container():
 
 def get_platform_info() -> dict:
     return {
-        'python_version': platform.python_version(),
-        'python_implementation': platform.python_implementation(),
+        # 'language_implementation': platform.python_implementation(),
+        'language': "python",
+        'language_version': platform.python_version(),
         'platform': sys.platform,
     }
 


### PR DESCRIPTION
## `add_project`
- Make `language` and `language_version` optional parameters.
- If not specified, they're likely using python - get version information.
- Send along platform and whether we are inside a container.