### PR TITLE
ENH: Improve configuration, API outputs

### DIFF
--- a/migas/config.py
+++ b/migas/config.py
@@ -74,7 +74,7 @@ class Config:
         endpoint: str = None,
         user_id: str = None,
         session_id: str = None,
-        force: bool = True,
+        force: bool = False,
         complete_init: bool = True,
     ) -> None:
         """
@@ -105,10 +105,10 @@ class Config:
 
     @classmethod
     @suppress_errors
-    def load(cls, filename: File) -> bool:
+    def load(cls, filename: File, force: bool = False) -> bool:
         """Load existing configuration file, or create a new one."""
         config = json.loads(Path(filename).read_text())
-        cls.init(complete_init=False, **config)
+        cls.init(complete_init=False, force=force, **config)
         return True
 
     @classmethod
@@ -137,8 +137,8 @@ def setup(
     session_id: str = None,
     save_config: bool = True,
     filename: File = None,
-    force: bool = True,
-) -> None:
+    force: bool = False,
+) -> bool:
     """
     Configure the client, and save configuration to an output file.
 
@@ -146,14 +146,15 @@ def setup(
     application developers for finer-grain control.
     """
     if not force and Config._is_setup:
-        return
+        return False
     filename = filename or DEFAULT_CONFIG_FILE
     if Path(filename).exists():
-        Config.load(filename)
+        Config.load(filename, force=force)
     # if any parameters have been set, override the current attribute
     Config.init(endpoint=endpoint, user_id=user_id, session_id=session_id, force=force)
     if save_config:
         Config.save(filename)
+    return True
 
 
 def gen_uuid(uuid_factory: str = "safe") -> str:

--- a/migas/tests/test_config.py
+++ b/migas/tests/test_config.py
@@ -26,9 +26,9 @@ def test_setup_default():
     assert conf.session_id is None
     assert conf._is_setup is True
 
-    # after being set up, can be changed by forcing
+    # after being set up, will not be changed unless forcing
     new_endpoint = 'https://github.com'
-    config.setup(force=False, endpoint=new_endpoint)
+    config.setup(endpoint=new_endpoint)
     assert conf.endpoint == config.DEFAULT_ENDPOINT
     config.setup(force=True, endpoint=new_endpoint)
     assert conf.endpoint == new_endpoint
@@ -39,7 +39,8 @@ def test_setup_default():
     config_dict['session_id'] = nuid
     config.DEFAULT_CONFIG_FILE.write_text(json.dumps(config_dict))
     assert conf.session_id is None
-    conf.load(config.DEFAULT_CONFIG_FILE)
+    # again, forcing is required to overwrite
+    conf.load(config.DEFAULT_CONFIG_FILE, force=True)
     assert conf.session_id == nuid
 
     # can be reset altogether

--- a/migas/tests/test_config.py
+++ b/migas/tests/test_config.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 
 import pytest
@@ -25,13 +26,23 @@ def test_setup_default():
     assert conf.session_id is None
     assert conf._is_setup is True
 
-    # after being set up, cannot be overriden
+    # after being set up, can be changed by forcing
     new_endpoint = 'https://github.com'
-    config.setup(endpoint=new_endpoint)
+    config.setup(force=False, endpoint=new_endpoint)
     assert conf.endpoint == config.DEFAULT_ENDPOINT
+    config.setup(force=True, endpoint=new_endpoint)
+    assert conf.endpoint == new_endpoint
 
-    # but fine if cleared
+    # ensure loading is working
+    nuid = '00000000-0000-0000-0000-000000000000'
+    config_dict = json.loads(config.DEFAULT_CONFIG_FILE.read_text())
+    config_dict['session_id'] = nuid
+    config.DEFAULT_CONFIG_FILE.write_text(json.dumps(config_dict))
+    assert conf.session_id is None
+    conf.load(config.DEFAULT_CONFIG_FILE)
+    assert conf.session_id == nuid
+
+    # can be reset altogether
     conf._reset()
     assert conf.endpoint is None
-    config.setup(endpoint=new_endpoint)
-    assert conf.endpoint == new_endpoint
+    assert conf.session_id is None


### PR DESCRIPTION
This PR adds filtering to the `get_usage` / `add_project` server response, to produce easily parsable dictionaries to be used by downstream packages.

Additionally, this fixes a bug in cases where `Confg._is_setup` being `True` was not allowing overwriting of config attributes.