### PR TITLE
TST: Add test for when username is unavailable

### DIFF
--- a/migas/config.py
+++ b/migas/config.py
@@ -182,5 +182,11 @@ def _safe_uuid_factory() -> str:
     import getpass
     import socket
 
-    name = f"{getpass.getuser()}@{os.getenv('HOSTNAME', socket.gethostname())}"
+    try:
+        user = getpass.getuser()
+    except KeyError:
+        # fails in cases of running docker containers as non-root
+        user = f'user-{os.getuid()}'
+
+    name = f"{user}@{os.getenv('HOSTNAME', socket.gethostname())}"
     return str(uuid.uuid3(uuid.NAMESPACE_DNS, name))

--- a/migas/tests/test_config.py
+++ b/migas/tests/test_config.py
@@ -47,3 +47,24 @@ def test_setup_default():
     conf._reset()
     assert conf.endpoint is None
     assert conf.session_id is None
+
+
+def test_safe_uuid_factory(monkeypatch):
+    import getpass
+
+    uid0 = config._safe_uuid_factory()
+    assert uid0
+
+    def none():
+        users = {}
+        return users['none']
+
+    # simulate unknown user
+    monkeypatch.setattr(getpass, 'getuser', none)
+    with pytest.raises(KeyError):
+        getpass.getuser()
+
+    uid1 = config._safe_uuid_factory()
+    assert uid1
+
+    assert uid0 != uid1


### PR DESCRIPTION
Came up while integrating into nipreps/nibabies

```
Traceback (most recent call last):
  File "/opt/conda/bin/nibabies", line 8, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.9/site-packages/nibabies/cli/run.py", line 28, in main
    ping_migas()
  File "/opt/conda/lib/python3.9/site-packages/nibabies/utils/misc.py", line 135, in ping_migas
    res = migas.add_project(
  File "/opt/conda/lib/python3.9/site-packages/migas/config.py", line 43, in can_send
    setup(force=False)
  File "/opt/conda/lib/python3.9/site-packages/migas/config.py", line 154, in setup
    Config.init(endpoint=endpoint, user_id=user_id, session_id=session_id, force=force)
  File "/opt/conda/lib/python3.9/site-packages/migas/config.py", line 96, in init
    cls.user_id = gen_uuid()
  File "/opt/conda/lib/python3.9/site-packages/migas/config.py", line 175, in gen_uuid
    return _safe_uuid_factory()
  File "/opt/conda/lib/python3.9/site-packages/migas/config.py", line 185, in _safe_uuid_factory
    name = f"{getpass.getuser()}@{os.getenv('HOSTNAME', socket.gethostname())}"
  File "/opt/conda/lib/python3.9/getpass.py", line 169, in getuser
    return pwd.getpwuid(os.getuid())[0]
KeyError: 'getpwuid(): uid not found: 1001'
```