### PR TITLE
RF: Clean up request functionality

### DIFF
--- a/migas/operations.py
+++ b/migas/operations.py
@@ -69,7 +69,7 @@ def get_usage(
     """
     params = _introspec(get_usage, locals())
     query = _formulate_query(params, getUsage)
-    _, response = request(Config.endpoint, query)
+    _, response = request(Config.endpoint, query=query)
     res = _filter_response(response, 'get_usage', getUsage["response"])
     return res
 
@@ -132,7 +132,7 @@ def add_project(
     # TODO: 3.9 - Replace with | operator
     params = {**compile_info(), **parameters}
     query = _formulate_query(params, addProject)
-    _, response = request(Config.endpoint, query)
+    _, response = request(Config.endpoint, query=query)
     res = _filter_response(response, 'add_project', addProject["response"])
     return res
 

--- a/migas/tests/test_request.py
+++ b/migas/tests/test_request.py
@@ -8,15 +8,20 @@ POST_QUERY = 'query{get_usage{project:"git/hub",start:"2022-07-01"}}'
 
 
 @pytest.mark.parametrize(
-    'endpoint,body,method', [(DEFAULT_ENDPOINT, POST_QUERY, "POST"), (ROOT, '', "GET")]
+    'endpoint,query,method', [(DEFAULT_ENDPOINT, POST_QUERY, "POST"), (ROOT, None, "GET")]
 )
-def test_request(endpoint, body, method):
-    status, res = request(endpoint, body, method=method)
+def test_request(endpoint, query, method):
+    status, res = request(endpoint, query=query, method=method)
     assert status == 200
     assert res
 
 
-def test_timeout():
-    status, res = request(ROOT, '', timeout=0.00001, method="GET")
+def test_timeout(monkeypatch):
+    status, res = request(ROOT, timeout=0.00001, method="GET")
+    assert status == 408
+    assert res['errors']
+
+    monkeypatch.setenv('MIGAS_TIMEOUT', '0.000001')
+    status, res = request(ROOT, method="GET")
     assert status == 408
     assert res['errors']

--- a/migas/tests/test_request.py
+++ b/migas/tests/test_request.py
@@ -11,7 +11,7 @@ POST_QUERY = 'query{get_usage{project:"git/hub",start:"2022-07-01"}}'
     'endpoint,query,method', [(DEFAULT_ENDPOINT, POST_QUERY, "POST"), (ROOT, None, "GET")]
 )
 def test_request(endpoint, query, method):
-    status, res = request(endpoint, query=query, method=method)
+    status, res = request(endpoint, query=query, method=method, timeout=5)
     assert status == 200
     assert res
 


### PR DESCRIPTION
Makes GET requests easier by isolating POST bits.
Adds `MIGAS_TIMEOUT` envvar to allow finer timeout control.