### PR TITLE
REWORK: Move configuration scope from user to process

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,33 @@ A Python package to communicate with a migas server.
 `migas` (*mee-gahs*) is a Python client to facilitate communication with a [`migas` server](https://github.com/mgxd/migas-server).
 
 
-## API
+## Usage
+
+To start communicating with a `migas` server, the client must first be setup.
+
+```python
+import migas; migas.setup()
+```
+
+By default, `migas-py` will communicate with the official hosted `migas` server.
+However it can easily be configured to communicate with any hosted `migas` server.
+
+```python
+import migas; migas.setup(endpoint='your-endpoint')
+```
+
+`setup()` will populate the [interal configuration](#configuration), which is done at the process level.
+
+### API
 
 `migas` includes the following functions to communicate with the telemetry server:
 
-### migas.add_project()
+#### migas.add_project()
 
 Send a breadcrumb with usage information to the server.
 Usage information includes:
  - application
  - application version
- - python version
- - operating system
  - application status
 
 The server will attempt to return version information about the project.
@@ -38,7 +53,7 @@ The server will attempt to return version information about the project.
 </details>
 
 
-### migas.get_usage()
+#### migas.get_usage()
 
 Check number of uses a `project` has received from a start date, and optionally an end date.
 If no end date is specified, the current datetime is used.
@@ -53,18 +68,21 @@ If no end date is specified, the current datetime is used.
 
 </details>
 
-## Customization
+## User Control
 
-By default, `migas-py` will communicate with our hosted `migas server`, however it can easily be configured to communicate with any `migas server`.
+`migas` can controlled by the following environmental variables:
 
-To configure the client:
+| Envvar | Description | Value |
+| ---- | ---- | ---- |
+| MIGAS_OPTOUT | Disable telemetry collection | Any |
+| MIGAS_TIMEOUT | Seconds to wait for server response | Number >= 0 |
 
-```python
-import migas; migas.setup(endpoint='your-custom-endpoint-here', force=True)
-```
 
+## Configuration
 
-### Environmental variables
+The internal configuration stores the following telemetry information:
 
-To enable `migas`, you must have a non-empty environmental variable `ENABLE_MIGAS` set.
-Additionally, you may control the request timeout by setting `MIGAS_TIMEOUT`.
+- language and language version
+- operating system
+- run within a container
+- run from continuous integration

--- a/migas/__init__.py
+++ b/migas/__init__.py
@@ -2,12 +2,13 @@ from . import _version
 
 __version__ = _version.get_versions()['version']
 
-from .config import setup
+from .config import print_config, setup
 from .operations import add_project, get_usage
 
 __all__ = (
     "__version__",
     "add_project",
     "get_usage",
+    "print_config",
     "setup",
 )

--- a/migas/config.py
+++ b/migas/config.py
@@ -9,6 +9,7 @@ from tempfile import gettempdir
 
 from .utils import compile_info
 
+DEFAULT_ROOT = 'https://migas.herokuapp.com/'
 DEFAULT_ENDPOINT = 'https://migas.herokuapp.com/graphql'
 DEFAULT_CONFIG_FILE_FMT = str(Path(gettempdir()) / 'migas-{pid}.json').format
 

--- a/migas/config.py
+++ b/migas/config.py
@@ -35,13 +35,11 @@ def telemetry_enabled(func: typing.Callable) -> typing.Callable:
 
     @wraps(func)
     def can_send(*args, **kwargs):
-        if not os.getenv("ENABLE_MIGAS", "0").lower() in ("1", "true", "y", "yes"):
+        if os.getenv("MIGAS_OPTOUT"):
             # do not communicate with server
             return {
                 "success": False,
-                "errors": [
-                    {"message": "migas is not enabled - set ENABLE_MIGAS environment variable."}
-                ],
+                "errors": [{"message": "migas telemetry is disabled."}],
             }
         if not Config._is_setup:
             return {

--- a/migas/config.py
+++ b/migas/config.py
@@ -77,6 +77,7 @@ class Config:
     language_version: str = None
     platform: str = None
     container: str = None
+    is_ci: bool = None
 
     @classmethod
     def init(
@@ -153,12 +154,11 @@ def setup(
     save_config: bool = True,
 ) -> None:
     """
-    Configure the client, and save configuration to an output file.
+    Prepare the client to communicate with a migas server.
 
-    # This method is invoked before each API call, but can also be called by
-    # application developers for finer-grain control.
+    This method is required prior to calling the API.
 
-    This method must be called before communicating with the server.
+    If `user_id` is not provided, one will be generated.
     """
     if filename is not None:
         _try_load(filename)
@@ -183,6 +183,7 @@ def setup(
             language_version=info['language_version'],
             platform=info['platform'],
             container=info['container'],
+            is_ci=info['is_ci'],
         )
     if save_config:
         Config.save(filename or DEFAULT_CONFIG_FILE_FMT(pid=os.getpid()))

--- a/migas/conftest.py
+++ b/migas/conftest.py
@@ -1,0 +1,9 @@
+def pytest_sessionstart(session):
+    """
+    If using a Free Hobby Heroku app, it may be asleep, which can cause timeout issues.
+    """
+    import requests
+
+    from migas.config import DEFAULT_ROOT
+
+    requests.get(DEFAULT_ROOT)

--- a/migas/tests/test_config.py
+++ b/migas/tests/test_config.py
@@ -49,6 +49,7 @@ def test_setup_default(tmp_path):
     assert conf.language_version
     assert conf.platform
     assert conf.container
+    assert conf.is_ci
 
 
 def test_safe_uuid_factory(monkeypatch):

--- a/migas/tests/test_config.py
+++ b/migas/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .. import config
+from migas import config
 
 
 def test_setup_default(tmp_path):
@@ -70,6 +70,33 @@ def test_safe_uuid_factory(monkeypatch):
     assert uid1
 
     assert uid0 != uid1
+
+
+def test_multiproc_config(tmp_path):
+    import os
+    import subprocess as sp
+
+    this_pid = os.getpid()
+    conf = config.Config
+    config.setup(endpoint='abcdef')  # populate with custom endpoint
+
+    code = """
+import os
+print(os.getppid())
+"""
+    proc = sp.run(['python'], input=code, capture_output=True, encoding='UTF-8')
+    child_parent_pid = proc.stdout.strip()
+    assert str(this_pid) == child_parent_pid
+
+    code = """
+import migas
+migas.setup()
+migas.print_config()
+"""
+    proc = sp.run(['python'], input=code, capture_output=True, encoding='UTF-8')
+    child_config = proc.stdout.strip()
+    print(child_config)
+    assert 'abcdef' in child_config
 
 
 def test_print_config(capsys):

--- a/migas/tests/test_config.py
+++ b/migas/tests/test_config.py
@@ -1,18 +1,10 @@
-import json
-import uuid
-
 import pytest
 
 from .. import config
 
 
-@pytest.fixture(autouse=True)
-def tmp_config(tmp_path, monkeypatch):
-    home = tmp_path / 'config.json'
-    monkeypatch.setattr(config, 'DEFAULT_CONFIG_FILE', home)
-
-
-def test_setup_default():
+def test_setup_default(tmp_path):
+    from uuid import UUID
 
     conf = config.Config
     assert conf.endpoint is None
@@ -22,31 +14,41 @@ def test_setup_default():
 
     config.setup()
     assert conf.endpoint == config.DEFAULT_ENDPOINT
-    assert uuid.UUID(conf.user_id)
+    assert UUID(conf.user_id)
     assert conf.session_id is None
     assert conf._is_setup is True
+    conf_file = conf._file
+    user_id = conf.user_id
 
-    # after being set up, will not be changed unless forcing
-    new_endpoint = 'https://github.com'
-    config.setup(endpoint=new_endpoint)
-    assert conf.endpoint == config.DEFAULT_ENDPOINT
-    config.setup(force=True, endpoint=new_endpoint)
+    # if setup is called again, overwrite existing
+    new_endpoint = 'https://migas-staging.herokuapp.com/graphql'
+    new_user = '00000000-0000-0000-0000-000000000000'
+    config.setup(endpoint=new_endpoint, user_id=new_user)
     assert conf.endpoint == new_endpoint
+    assert conf.user_id == new_user
+    # but invalid UUIDs are not used
+    config.setup(user_id='abc')
+    assert conf.user_id != 'abc'
 
-    # ensure loading is working
-    nuid = '00000000-0000-0000-0000-000000000000'
-    config_dict = json.loads(config.DEFAULT_CONFIG_FILE.read_text())
-    config_dict['session_id'] = nuid
-    config.DEFAULT_CONFIG_FILE.write_text(json.dumps(config_dict))
-    assert conf.session_id is None
-    # again, forcing is required to overwrite
-    conf.load(config.DEFAULT_CONFIG_FILE, force=True)
-    assert conf.session_id == nuid
-
-    # can be reset altogether
+    # can be reset
     conf._reset()
     assert conf.endpoint is None
     assert conf.session_id is None
+    # and loaded
+    conf.load(conf_file)
+    assert conf.endpoint == config.DEFAULT_ENDPOINT
+    assert conf.user_id == user_id
+
+    # user provided output file
+    myfile = tmp_path / 'config.json'
+    config.setup(filename=myfile)
+    assert str(conf._file) == str(myfile)
+
+    # system information is available
+    assert conf.language
+    assert conf.language_version
+    assert conf.platform
+    assert conf.container
 
 
 def test_safe_uuid_factory(monkeypatch):
@@ -68,3 +70,12 @@ def test_safe_uuid_factory(monkeypatch):
     assert uid1
 
     assert uid0 != uid1
+
+
+def test_print_config(capsys):
+    config.setup()
+    config.print_config()
+    captured = capsys.readouterr()
+    for field in config.Config.__dataclass_fields__.keys():
+        assert field in captured.out
+        assert str(getattr(config.Config, field)) in captured.out

--- a/migas/tests/test_config.py
+++ b/migas/tests/test_config.py
@@ -49,7 +49,7 @@ def test_setup_default(tmp_path):
     assert conf.language_version
     assert conf.platform
     assert conf.container
-    assert conf.is_ci
+    assert isinstance(conf.is_ci, bool)
 
 
 def test_safe_uuid_factory(monkeypatch):

--- a/migas/tests/test_request.py
+++ b/migas/tests/test_request.py
@@ -1,14 +1,13 @@
 import pytest
 
-from migas.config import DEFAULT_ENDPOINT
+from migas.config import DEFAULT_ENDPOINT, DEFAULT_ROOT
 from migas.request import request
 
-ROOT = 'https://migas.herokuapp.com/'
 POST_QUERY = 'query{get_usage{project:"git/hub",start:"2022-07-01"}}'
 
 
 @pytest.mark.parametrize(
-    'endpoint,query,method', [(DEFAULT_ENDPOINT, POST_QUERY, "POST"), (ROOT, None, "GET")]
+    'endpoint,query,method', [(DEFAULT_ENDPOINT, POST_QUERY, "POST"), (DEFAULT_ROOT, None, "GET")]
 )
 def test_request(endpoint, query, method):
     status, res = request(endpoint, query=query, method=method, timeout=5)
@@ -17,11 +16,11 @@ def test_request(endpoint, query, method):
 
 
 def test_timeout(monkeypatch):
-    status, res = request(ROOT, timeout=0.00001, method="GET")
+    status, res = request(DEFAULT_ROOT, timeout=0.00001, method="GET")
     assert status == 408
     assert res['errors']
 
     monkeypatch.setenv('MIGAS_TIMEOUT', '0.000001')
-    status, res = request(ROOT, method="GET")
+    status, res = request(DEFAULT_ROOT, method="GET")
     assert status == 408
     assert res['errors']

--- a/migas/tests/test_request.py
+++ b/migas/tests/test_request.py
@@ -10,7 +10,7 @@ POST_QUERY = 'query{get_usage{project:"git/hub",start:"2022-07-01"}}'
     'endpoint,query,method', [(DEFAULT_ENDPOINT, POST_QUERY, "POST"), (DEFAULT_ROOT, None, "GET")]
 )
 def test_request(endpoint, query, method):
-    status, res = request(endpoint, query=query, method=method, timeout=5)
+    status, res = request(endpoint, query=query, method=method)
     assert status == 200
     assert res
 

--- a/migas/utils.py
+++ b/migas/utils.py
@@ -4,10 +4,6 @@ import sys
 from pathlib import Path
 
 
-def is_ci():
-    ...
-
-
 def is_container():
     root = Path('/')
     if (root / '.dockerenv').exists():
@@ -27,6 +23,9 @@ def get_platform_info() -> dict:
 
 
 def compile_info() -> dict:
+    from ci_info import is_ci
+
     data = get_platform_info()
     data['container'] = is_container()
+    data['is_ci'] = is_ci()
     return data

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ dev =
     black
     isort
 test =
+    requests
     pytest
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ project_urls =
 [options]
 python_requires = >= 3.7
 install_requires =
-    ci-info >= 0.2
+    ci-info >= 0.3
     typing_extensions; python_version<'3.8'
 
 [options.extras_require]


### PR DESCRIPTION
This is a follow up to the ideas brought up in #23 

- `migas.setup()` is now required before interacting with a migas server.
- platform information is now collected on setup - will be used in `add_project()`
- attempt to load earlier configuration files - if a process is identified as a child process of the original migas call, the configuration is reused.