### PR TITLE
ENH: Report `is_ci` results to `add_project`, use precompiled results

### DIFF
--- a/migas/config.py
+++ b/migas/config.py
@@ -137,6 +137,24 @@ class Config:
         cls._file = filename
 
     @classmethod
+    def populate(cls) -> dict:
+        res = {
+            f: getattr(cls, f)
+            for f in (
+                'user_id',
+                'session_id',
+                'language',
+                'language_version',
+                'platform',
+                'container',
+            )
+            if getattr(cls, f) is not None
+        }
+        # boolean syntax
+        res['is_ci'] = str(cls.is_ci).lower()
+        return res
+
+    @classmethod
     def _reset(cls) -> None:
         """Reset the config class attributes."""
         cls.endpoint = None

--- a/migas/operations.py
+++ b/migas/operations.py
@@ -8,7 +8,6 @@ from uuid import UUID
 
 from migas.config import Config, telemetry_enabled
 from migas.request import request
-from migas.utils import compile_info
 
 if sys.version_info[:2] >= (3, 8):
     from typing import TypedDict
@@ -82,6 +81,7 @@ addProject: OperationTemplate = {
         "project_version": '"{}"',
         "language": '"{}"',
         "language_version": '"{}"',
+        "is_ci": '{}',
         # optional
         "status": "{}",
         "user_id": '"{}"',
@@ -128,11 +128,9 @@ def add_project(
     A dictionary containing the latest released version of the project,
     as well as any messages sent by the developers.
     """
-    if not user_id:
-        user_id = Config.user_id
     parameters = _introspec(add_project, locals())
     # TODO: 3.9 - Replace with | operator
-    params = {**compile_info(), **parameters}
+    params = {**Config.populate(), **parameters}
     query = _formulate_query(params, addProject)
     _, response = request(Config.endpoint, query=query)
     res = _filter_response(response, 'add_project', addProject["response"])


### PR DESCRIPTION
Blocked until production server supports `is_ci` field.