### PR TITLE
ENH: Change `add_project()` and `get_usage()` signatures, add testing for each

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If no end date is specified, the current datetime is used.
 
 ```python
 >>> get_usage('mgxd/migas-py', '2022-07-01')
-{'hits': 7, 'message': '', 'unique': False}
+{'hits': 7, 'message': '', 'unique': False, 'success': True}
 ```
 
 </details>

--- a/migas/config.py
+++ b/migas/config.py
@@ -70,6 +70,15 @@ class Config:
     _file: File = None
     _pid: int = None
     _is_setup: bool = False
+    _telemetry_attrs = (
+        'user_id',
+        'session_id',
+        'language',
+        'language_version',
+        'platform',
+        'container',
+        'is_ci',
+    )
     endpoint: str = None
     user_id: str = None
     session_id: str = None
@@ -138,21 +147,7 @@ class Config:
 
     @classmethod
     def populate(cls) -> dict:
-        res = {
-            f: getattr(cls, f)
-            for f in (
-                'user_id',
-                'session_id',
-                'language',
-                'language_version',
-                'platform',
-                'container',
-            )
-            if getattr(cls, f) is not None
-        }
-        # boolean syntax
-        res['is_ci'] = str(cls.is_ci).lower()
-        return res
+        return {f: getattr(cls, f) for f in cls._telemetry_attrs if getattr(cls, f) is not None}
 
     @classmethod
     def _reset(cls) -> None:

--- a/migas/conftest.py
+++ b/migas/conftest.py
@@ -1,9 +1,19 @@
-def pytest_sessionstart(session):
+import pytest
+
+TEST_ROOT = "https://migas-staging.herokuapp.com/"
+TEST_ENDPOINT = f"{TEST_ROOT}graphql"
+
+
+def pytest_sessionstart(session) -> None:
     """
     If using a Free Hobby Heroku app, it may be asleep, which can cause timeout issues.
+    This sends a ping to allow the server to wakeup.
     """
     import requests
 
-    from migas.config import DEFAULT_ROOT
+    requests.get(TEST_ROOT)
 
-    requests.get(DEFAULT_ROOT)
+
+@pytest.fixture(scope="session")
+def endpoint() -> str:
+    return TEST_ENDPOINT

--- a/migas/operations.py
+++ b/migas/operations.py
@@ -4,7 +4,6 @@ Create queries and mutations to be sent to the graphql endpoint.
 import sys
 import typing
 from http.client import HTTPResponse
-from uuid import UUID
 
 from migas.config import Config, telemetry_enabled
 from migas.request import request
@@ -48,7 +47,7 @@ def get_usage(
     project: str,
     start: str,
     end: str = None,
-    # unique: bool = False,  # TODO: Add once supported in server
+    unique: bool = False,
 ) -> dict:
     """
     Query project usage.
@@ -61,6 +60,8 @@ def get_usage(
     `start` and `end` can be in either of the following formats:
         - YYYY-MM-DD
         - YYYY-MM-DDTHH:MM:SSZ
+
+    If `unique` is set to `True`, aggregates multiple uses by the same user as a single use.
 
     Returns
     -------

--- a/migas/tests/test_operations.py
+++ b/migas/tests/test_operations.py
@@ -50,5 +50,5 @@ def test_get_usage():
     assert all_usage >= res['hits'] > 0
 
     res = get_usage(test_project, start=future())
-    assert res['success'] is True
+    assert res['success'] is False
     assert res['hits'] == 0

--- a/migas/tests/test_operations.py
+++ b/migas/tests/test_operations.py
@@ -1,0 +1,54 @@
+import pytest
+
+from migas import __version__, setup
+from migas.operations import add_project, get_usage
+
+test_project = 'mgxd/migas-py'
+
+
+def future() -> str:
+    from datetime import datetime, timedelta
+
+    return (datetime.utcnow() + timedelta(days=2)).strftime('%Y-%m-%d')
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_migas(endpoint):
+    """Ensure migas is configured to communicate with the staging app."""
+    setup(endpoint=endpoint)
+
+
+def test_add_project():
+
+    res = add_project(test_project, __version__)
+    assert res['success'] is True
+    latest = res['latest_version']
+    assert latest
+
+    # ensure kwargs can be submitted
+    res = add_project(test_project, __version__, language='cpython', platform='win32')
+    assert res['success'] is True
+    assert res['latest_version'] == latest
+    # should be cached since we just checked the version
+    assert res['cached'] is True
+
+    # illegal queries should fail
+    res = add_project(test_project, __version__, status='wtf')
+    assert res['success'] is False
+    assert res['latest_version'] is None
+
+
+def test_get_usage():
+    y2k = '2000-01-01'
+    res = get_usage(test_project, start=y2k)
+    assert res['success'] is True
+    all_usage = res['hits']
+    assert res['hits'] > 0
+
+    res = get_usage(test_project, start=y2k, unique=True)
+    assert res['success'] is True
+    assert all_usage >= res['hits'] > 0
+
+    res = get_usage(test_project, start=future())
+    assert res['success'] is True
+    assert res['hits'] == 0

--- a/migas/tests/test_request.py
+++ b/migas/tests/test_request.py
@@ -1,26 +1,31 @@
 import pytest
 
-from migas.config import DEFAULT_ENDPOINT, DEFAULT_ROOT
 from migas.request import request
 
-POST_QUERY = 'query{get_usage{project:"git/hub",start:"2022-07-01"}}'
+GET_URL = 'https://httpbin.org/get'
+POST_URL = 'https://httpbin.org/post'
 
 
 @pytest.mark.parametrize(
-    'endpoint,query,method', [(DEFAULT_ENDPOINT, POST_QUERY, "POST"), (DEFAULT_ROOT, None, "GET")]
+    'method,url,query', [('POST', POST_URL, 'mydata'), ('GET', GET_URL, None)]
 )
-def test_request(endpoint, query, method):
-    status, res = request(endpoint, query=query, method=method)
+def test_request_get(method, url, query):
+    status, res = request(url, query=query, method=method)
     assert status == 200
     assert res
 
 
 def test_timeout(monkeypatch):
-    status, res = request(DEFAULT_ROOT, timeout=0.00001, method="GET")
+    status, res = request(GET_URL, timeout=0.00001, method="GET")
     assert status == 408
     assert res['errors']
 
     monkeypatch.setenv('MIGAS_TIMEOUT', '0.000001')
-    status, res = request(DEFAULT_ROOT, method="GET")
+    status, res = request(GET_URL, method="GET")
     assert status == 408
     assert res['errors']
+
+    monkeypatch.delenv('MIGAS_TIMEOUT')
+    status, res = request(GET_URL, method="GET")
+    assert status == 200
+    assert res


### PR DESCRIPTION
This PR allows any keyword arguments for `add_project()`, and moves defaults into the Config module after #24.

Additionally, `get_usage()`'s `unique` parameter is unlocked, as it has been implemented upstream.

Includes much needed testing for `add_project()` and `get_usage()` operations.